### PR TITLE
Fix requirements file

### DIFF
--- a/fingerprint-api/requirements.txt
+++ b/fingerprint-api/requirements.txt
@@ -6,4 +6,3 @@ requests
 pytest
 pytest-asyncio
 sqlalchemy
-```


### PR DESCRIPTION
## Summary
- remove stray code fence from requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684a13d604808333bfc708f64cf02183