### PR TITLE
Update Docker CMD path

### DIFF
--- a/fingerprint-api/Dockerfile
+++ b/fingerprint-api/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./src ./src
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]


### PR DESCRIPTION
## Summary
- point the Docker `CMD` at `src.main:app`

## Testing
- `pip install -r /tmp/req.txt`
- `pytest fingerprint-api/tests` *(fails: ModuleNotFoundError: api)*

------
https://chatgpt.com/codex/tasks/task_e_684a1426b5f08333b2f797a1e57e2930